### PR TITLE
pn544: fix ifdef

### DIFF
--- a/include/linux/nfc/pn544.h
+++ b/include/linux/nfc/pn544.h
@@ -17,7 +17,7 @@
  *
  */
 
-#ifdef CONFIG_LGE_NFC_PN547_C2
+#ifndef PN544_SET_PWR
 #ifndef _PN547_LGE_H_
 #define _PN547_LGE_H_
 


### PR DESCRIPTION
* stupid fucking ls990 builds a hal which has this defined already
  but the other variants need it for the hal they build

Change-Id: I1a054c482ed32125ae8c413cfb4a0e056461c2a2